### PR TITLE
Prevent ReflectionTypeLoadException

### DIFF
--- a/Assets/BansheeGz/BGCurve/Scripts/Editor/CcInfra/BGCcTreeView.cs
+++ b/Assets/BansheeGz/BGCurve/Scripts/Editor/CcInfra/BGCcTreeView.cs
@@ -78,12 +78,19 @@ namespace BansheeGz.BGSpline.Editor
             var result = new List<Type>();
             var assemblies = AppDomain.CurrentDomain.GetAssemblies();
             foreach (var assembly in assemblies)
-                result.AddRange(from type in assembly.GetTypes()
-                    where type.IsClass
-                    where !type.IsAbstract
-                    where type.IsSubclassOf(targetType)
-                    where excludeAttributeType == null || BGReflectionAdapter.GetCustomAttributes(type, excludeAttributeType, true).Length == 0
-                    select type);
+                try
+                {
+                    result.AddRange(from type in assembly.GetTypes()
+                                    where type.IsClass
+                                    where !type.IsAbstract
+                                    where type.IsSubclassOf(targetType)
+                                    where excludeAttributeType == null || BGReflectionAdapter.GetCustomAttributes(type, excludeAttributeType, true).Length == 0
+                                    select type);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning($"{assembly.FullName} threw ReflectionTypeLoadException\r\n{e}");
+                }
 
             return result.ToArray();
         }


### PR DESCRIPTION
Some libraries will cause GetTypes to throw a ReflectionTypeLoadException, preventing the TreeView from being rendered.
Instead of letting this cause the TreeView to fail, warn the user about the issue and skip the assembly