### PR TITLE
Setup BGCcEditor as a default fallback editor for BGCc

### DIFF
--- a/Assets/BansheeGz/BGCurve/Scripts/Editor/CcInfra/BGCcEditor.cs
+++ b/Assets/BansheeGz/BGCurve/Scripts/Editor/CcInfra/BGCcEditor.cs
@@ -4,6 +4,7 @@ using BansheeGz.BGSpline.Curve;
 using UnityEditor;
 namespace BansheeGz.BGSpline.Editor
 {
+	[CustomEditor(typeof(BGCc), true)]
     public class BGCcEditor : UnityEditor.Editor
     {
         public event EventHandler ChangedParent;
@@ -159,6 +160,7 @@ namespace BansheeGz.BGSpline.Editor
 
         protected virtual void InternalOnInspectorGUI()
         {
+			DrawPropertiesExcluding(serializedObject, "m_Script", "showHandles", "hidden", "ccName", "parent");
         }
 
         protected virtual void InternalOnSceneGUI()


### PR DESCRIPTION
Setup the BGCcEditor as a fallback editor and update InternalOnInspectorGUI to execute DrawPropertiesExcluding as a default implementation.
This way new curve components are not required to implement an editor, maintaining the editor workflow while adding them